### PR TITLE
Add OSCAL release v1.1.1 to news page

### DIFF
--- a/src/content/about/news/_index.md
+++ b/src/content/about/news/_index.md
@@ -11,5 +11,6 @@ menu:
     weight: 2
 ---
 
-- [OSCAL 1.1.0 Full Release](https://github.com/usnistgov/OSCAL/releases/tag/v1.1.0) - July 25, 2023
-- [OSCAL 1.0.6 Full Release](https://github.com/usnistgov/OSCAL/releases/tag/v1.0.6) - June 30, 2023
+- [OSCAL 1.1.1 Release](https://github.com/usnistgov/OSCAL/releases/tag/v1.1.1) - September 12, 2023
+- [OSCAL 1.1.0 Release](https://github.com/usnistgov/OSCAL/releases/tag/v1.1.0) - July 25, 2023
+- [OSCAL 1.0.6 Release](https://github.com/usnistgov/OSCAL/releases/tag/v1.0.6) - June 30, 2023


### PR DESCRIPTION
Backport update of the news page to align with missing release and our updated release guidance. This will serve as an example.

For context, https://github.com/usnistgov/OSCAL-Reference/pull/22#issuecomment-1735963715.