### PR TITLE
Update news with Sept. 2023 liboscal-java and oscal-cli releases

### DIFF
--- a/src/content/about/news/_index.md
+++ b/src/content/about/news/_index.md
@@ -11,6 +11,8 @@ menu:
     weight: 2
 ---
 
+- [oscal-cli 1.0.2 Release](https://github.com/usnistgov/oscal-cli/releases/v1.0.2) - September 29, 2023
+- [liboscal-java 3.0.2 Release](https://github.com/usnistgov/liboscal-java/releases/tag/v3.0.2) - September 21, 2023
 - [OSCAL 1.1.1 Release](https://github.com/usnistgov/OSCAL/releases/tag/v1.1.1) - September 12, 2023
 - [OSCAL 1.1.0 Release](https://github.com/usnistgov/OSCAL/releases/tag/v1.1.0) - July 25, 2023
 - [OSCAL 1.0.6 Release](https://github.com/usnistgov/OSCAL/releases/tag/v1.0.6) - June 30, 2023


### PR DESCRIPTION
With updated comms guidance and [updated checklists reviewed with @iMichaela](https://github.com/usnistgov/oscal-cli/wiki/#release-procedures) regarding releases and news, add oscal-cli release and backport recent liboscal-java release.