### PR TITLE
Fix broken link

### DIFF
--- a/src/content/resources/concepts/layer/implementation/component-definition/_index.md
+++ b/src/content/resources/concepts/layer/implementation/component-definition/_index.md
@@ -103,7 +103,7 @@ OSCAL is designed to allow capture relevant details related to independent valid
 
 The following tutorials are provided that are related to the component definition model.
 
-- [Creating a Component Definition](/learn/tutorials/simple-component-definition/): Covers creating a basic OSCAL component definition for a software product.
+- [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/): Covers creating a basic OSCAL component definition for a software product.
 - [Representing Test Validation Information](/learn/tutorials/validation-modeling/): Explains how to represent test validation information (e.g., FIPS-140-2) for a component in an OSCAL component definition.
 
 ## Content Examples


### PR DESCRIPTION
On this page: https://pages.nist.gov/OSCAL/resources/concepts/layer/implementation/component-definition/ 

The "Creating a Component Definition" link is broken.

Current link goes to:
https://pages.nist.gov/OSCAL/learn/tutorials/simple-component-definition/

Correct URL is:
https://pages.nist.gov/OSCAL/learn/tutorials/implementation/simple-component-definition/