### PR TITLE
Update basic-catalog.md with correct UUID in the Final Catalog JSON Example

### DIFF
--- a/src/content/learn/tutorials/control/basic-catalog.md
+++ b/src/content/learn/tutorials/control/basic-catalog.md
@@ -981,7 +981,7 @@ Assembling all of the control content described in this tutorial, we obtain the 
 {{< highlight json "linenos=table" >}}
 {
   "catalog" : {
-    "id" : "uuid-956c32af-8a15-4732-a4d9-f976a1149c4b",
+    "uuid" : "956c32af-8a15-4732-a4d9-f976a1149c4b",
     "metadata" : {
       "title" : "Sample Security Catalog",
       "published" : "2020-02-02T11:01:04.736-04:00",


### PR DESCRIPTION
Line 984 of the basic-catalog.md shows the Final Catalog 

    "id" : "uuid-956c32af-8a15-4732-a4d9-f976a1149c4b",

When it should be:

    "uuid" : "956c32af-8a15-4732-a4d9-f976a1149c4b",