### PR TITLE
Added April 2025 Workshop Blog & Improved OSCAL Reference Navigation

### DIFF
--- a/src/content/about/blog/_index.md
+++ b/src/content/about/blog/_index.md
@@ -16,11 +16,49 @@ menu:
 
 <p>Stay up-to-date with the newest blog posts from our OSCAL community members. Below you'll find a list of recent blog titles-simply click on any title to dive straight into the post you're interested in: </p>
 
+- **Revolutionizing Compliance Through Machine-Readable Data: A Student's Perspective** -- 04/16/2025 -- [Read More](#20250416)
 - **OSCAL Continues to Grow Roots in Europe** -- 04/09/2025 -- [Read More](#20250409)
 - **Exploring the OSCAL-based AI-augmented CISO Agent: A Student's Perspective** -- 03/19/2025 -- [Read More](#20250319)
 - **OSCAL Foundation launches to move security standard forward** -- 02/07/2025 -- [Read More](#20250207)
 
+##
+---
+### 2025/04/16
+## <span style="color:#4d80d1"> Revolutionizing Compliance Through Machine-Readable Data: A Student's Perspective </span>
+
+  #### -- Presented By: 
+  - **Brian Ruf**, *Independent Consultant, RufRisk*
+  - **Pirooz Javan**, *CTO, Easy Dynamics*
+  - **Juan Risso**, *Lead Software Engineer, Easy Dynamics*
+  ### <p></p>
+
+  ##### -- Blog by: Marilyn Nguyen (NIST Pathways, IT Student Trainee)
+
+I had the chance to attend a fascinating workshop titled "OSCAL Catalogs: Create Easily and Use Broadly," presented by experts Brian Ruf (RufRisk), Priooz Javan (Easy Dynamics), and Juan Risso (Easy Dynamics). The session gave a deep dive into OSCAL and its use in various industries. While I initially thought OSCAL was focused solely on cybersecurity compliance frameworks, I quickly learned that its applications can stretch far beyond that, offering a powerful tool for managing a wide variety of regulatory and requirement-based scenarios.
+
+At its core, OSCAL was created to handle cybersecurity requirements, including well-known frameworks such as NIST SP 800-53 and SOC 2. These are essential standards in managing cybersecurity risk and compliance, but the workshop revealed that OSCAL can be applied much more broadly. It turns out OSCAL is highly versatile and can be used to manage virtually any type of requirement (including products, services, or processes) across multiple industries. The ability to define requirements clearly, track their implementation, and assess compliance can be a game-changer for industries like healthcare, manufacturing, financial services, and even construction.
+
+What was particularly intriguing was the emphasis on machine-readable data. Traditionally, compliance requirements are stored in formats like PDFs or Word documents, which are difficult to track and are often prone to errors. OSCAL solves this problem by structuring data in a way that machines can easily process, enabling automation and reducing human error. The presenters explained that by starting with OSCAL, organizations can seamlessly convert human-readable formats like HTML, Word, and Excel into machine-readable data, ensuring that compliance documents are both accessible and actionable. This concept of bridging the gap between machine-readable and human-readable data was one of the most important takeaways from the workshop.
+
+The workshop also featured a live demonstration of the Comply Zero platform, which is built around OSCAL and helps manage compliance lifecycles. In the demo, we saw how OSCAL catalogs can be created, managed, and assessed through an intuitive interface. The ability to define controls, parameters, and assessment objectives, and link them together, showcased how OSCAL can help organizations streamline their compliance processes.
+
+One of the key points made during the workshop was the idea that OSCAL’s machine-readable format enables automation and more efficient tracking of compliance efforts. As regulations become more complex, tools like OSCAL will be essential in managing and evaluating compliance in real time, minimizing the risks of human error, and reducing the time spent manually cross-referencing documents. This is especially critical in industries where compliance is not just a best practice but a legal requirement. Starting with OSCAL allows organizations to build a solid foundation for automation, and the ability to generate reports and assessments more easily means that stakeholders can focus on the actual outcomes rather than the complexity of the paperwork.
+
+Overall, this workshop was incredibly informative. I walked away with a much deeper understanding of how OSCAL works and how it is revolutionizing the way industries track and assess compliance requirements. It became clear to me that OSCAL is more than just a tool for cybersecurity—it’s a versatile solution with broad potential applications in fields like healthcare, construction, manufacturing, and finance. As a student, I’m excited about the possibilities this open standard offers for the future of compliance management.
+
+### Location: 
+  - Online
+  
+  ### Date and Time:
+  - 16 April 2025, 11:00 AM - 12:00 PM EDT
+
 #
+  *View this April 2025 workshop recording and other files* [here](https://csrc.nist.gov/Projects/open-security-controls-assessment-language/oscal-adopters-workshops#:~:text=04/16/2025).
+  
+  *Learn more about the OSCAL Monthly Workshop series* [here](../../learn/presentations/mini-workshop#2025/3/19/).
+
+# <div></div>
+
 ---
 ### 2025/04/09
 ## <span style="color:#4d80d1">OSCAL Continues to Grow Roots in Europe

--- a/src/content/resources/_index.md
+++ b/src/content/resources/_index.md
@@ -2,6 +2,7 @@
 title: OSCAL Resources
 date: 2023-09-06 13:48:17 -0400
 heading: OSCAL Resources
+suppresstopiclist: true
 menu:
   primary:
     name: Resources
@@ -12,7 +13,7 @@ sidenav:
   activerenderdepth: 2
 ---
 
-The OSCAL project maintains a variety of resources to learn and use OSCAL.
+Find helpful guides, tools, and references to help you learn, implement, and get the most out of OSCAL. Whether you're just getting started or looking for advanced support, the resources below will support your journey with OSCAL.
 
 ### OSCAL Reference
 
@@ -23,12 +24,12 @@ For each released model, outline entries are linked to their corresponding refer
 
 ### Examples
 
-The [examples](./examples/) page has links and information to examples of OSCAL content in the official NIST repositories.
+Browse a collection of real-world OSCAL [examples](./examples/) from the official NIST repositories. These examples showcase how OSCAL can be used in practice, helping you better understand how to structure and implement your own content.
 
 ### Tools
 
-The [tools](./tools) page has information about NIST's reference implementations of software and reusable libraries. Additionally, there are links to community-maintained lists of software and information about OSCAL-enabled tools.
+Discover [tools](./tools) developed by NIST and the wider community to support OSCAL implementation. This page includes reference software, reusable libraries, and curated links to OSCAL-enabled tools maintained by contributors across the ecosystem.
 
 ### Downloads
 
-The [downloads](./downloads/) page has links and instructions to download releases and development snapshots of the OSCAL data models.
+Get the latest OSCAL data models here. The [downloads](./downloads/) page has links and clear instructions to help you download releases and development snapshots of the OSCAL data models.

--- a/src/content/resources/reference/_index.md
+++ b/src/content/resources/reference/_index.md
@@ -10,8 +10,16 @@ aliases:
 
 <br/><br/><br/>
 
-### This page has moved to the new OSCAL reference website at: 
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://pages.nist.gov/OSCAL-Reference/" />
+  </head>
+  <body>
+    <p>This page should automatically redirect to the OSCAL Reference page. If it does not, please <a href="https://pages.nist.gov/OSCAL-Reference/">click here</a>.</p>
+  </body>
+</html>
 
-## [The OSCAL Reference Page](https://pages.nist.gov/OSCAL-Reference/)
+## This page has moved to the new OSCAL reference website at: 
+# [The OSCAL Reference Page](https://pages.nist.gov/OSCAL-Reference/)
 
 <br/><br/><br/>


### PR DESCRIPTION
Updates made to streamline navigation and enhance the user experience:

- Updated the "OSCAL Reference" sidebar link to redirect directly to the external OSCAL Reference website, bypassing the transitional "moved" page.
- Revised descriptions on the main OSCAL Resources page to improve clarity and user experience.
- Added the April 2025 Workshop blog post.