### PR TITLE
Fix OSCAL converters tools link

### DIFF
--- a/src/content/learn/concepts/layer/overview.md
+++ b/src/content/learn/concepts/layer/overview.md
@@ -234,4 +234,4 @@ This allows developers to use their preferred format. A tool designed for one fo
 
 Currently, converters are available to convert XML-based OSCAL files to JSON and JSON-based OSCAL files to XML.
 
-For more details on converter usage, see the build and usage instructions on the [tools page](../../../tools/#data-conversion).
+For more details on converter usage, see the build and usage instructions on the [tools page](/resources/tools/#data-conversion).


### PR DESCRIPTION
## Summary

- Update the OSCAL converters tools page link to point to the current resources tools page.
- Keep the link targeted to the data conversion section.

## Validation

- Built the site with Hugo 0.110.0 using the workflow configuration.
- Checked the updated tools page URL with lychee.