### PR TITLE
Add policy and capability component-definition tutorials

### DIFF
--- a/src/content/learn/_index.md
+++ b/src/content/learn/_index.md
@@ -29,6 +29,8 @@ The [tutorials](./tutorials/) section provides step-by-step walk-throughs explai
 
 - [implementation layer tutorials](./tutorials/implementation/)
   - [Creating a Basic Component Definition](./tutorials/implementation/simple-component-definition/): Teaches how to create a component-definition using the OSCAL [component definition](/concepts/layer/implementation/component-definition/) model.
+  - [Creating a Policy Component](./tutorials/implementation/policy-component-definition/): Explains how to represent an organizational policy as a `type="policy"` component definition.
+  - [Modeling a Capability Component](./tutorials/implementation/capability-component-definition/): Explores an emerging, proposed pattern for representing a capability as a `type="capability"` component definition.
   - [Representing proof of compliance or test validation information](./tutorials/implementation/validation-modeling/): Describes how to represent test validation information (e.g., FIPS-140-2) using a component in an OSCAL [component definition](/concepts/layer/implementation/component-definition/) or [system security plan](/concepts/layer/implementation/ssp/). 
 
 ### Events and Presentations

--- a/src/content/learn/concepts/layer/implementation/component-definition/_index.md
+++ b/src/content/learn/concepts/layer/implementation/component-definition/_index.md
@@ -105,6 +105,8 @@ The following tutorials are provided that are related to the component definitio
 
 - [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/): Covers creating a basic OSCAL component definition for a software product.
 - [Representing Test Validation Information](/learn/tutorials/validation-modeling/): Explains how to represent test validation information (e.g., FIPS-140-2) for a component in an OSCAL component definition.
+- [Creating a Policy Component](/learn/tutorials/implementation/policy-component-definition/): Explains how to represent an organizational policy as a `type="policy"` component definition.
+- [Modeling a Capability Component](/learn/tutorials/implementation/capability-component-definition/): Explores an emerging, proposed pattern for representing a capability as a `type="capability"` component definition.
 
 ## Content Examples
 

--- a/src/content/learn/tutorials/_index.md
+++ b/src/content/learn/tutorials/_index.md
@@ -70,6 +70,16 @@ This page serves as the central hub for all OSCAL tutorials. Learn how to build,
             <strong><a href="implementation/validation-modeling/" style="color: #4d8055;">Representing Test Validation Information</a></strong><br>
             Capture test validation results (e.g., FIPS 140-2) in a component definition or system security plan</a>.
         </div>
+    <!-- Subsection: "Creating a Policy Component" Box -->
+        <div style="flex: 1 1 280px; background-color: #ecf3ec; padding: 1em; border-radius: 6px; border-left: 4px solid #4d8055;">
+            <strong><a href="implementation/policy-component-definition/" style="color: #4d8055;">Creating a Policy Component</a></strong><br>
+            Represent an organizational policy as a <code>type="policy"</code> component definition.
+        </div>
+    <!-- Subsection: "Modeling a Capability Component" Box -->
+        <div style="flex: 1 1 280px; background-color: #ecf3ec; padding: 1em; border-radius: 6px; border-left: 4px solid #4d8055;">
+            <strong><a href="implementation/capability-component-definition/" style="color: #4d8055;">Modeling a Capability Component</a></strong><br>
+            Explore a proposed pattern for representing a capability as a <code>type="capability"</code> component.
+        </div>
     </div>
   </div>
 </div>

--- a/src/content/learn/tutorials/implementation/_index.md
+++ b/src/content/learn/tutorials/implementation/_index.md
@@ -38,4 +38,22 @@ Understand the process of representing test validation information (e.g., FIPS-1
 
 [Read Tutorial →](validation-modeling/)
 </div>
+
+<!-- Box containing information about creating policy component definitions -->
+<div style="flex: 1 1 300px; border-left: 4px solid #4d8055; background-color: #ecf3ec; padding: 1em; border-radius: 6px;">
+
+<strong>Creating a Policy Component</strong><br>
+Learn how to represent an organizational policy as a `type="policy"` [component definition](/concepts/layer/implementation/component-definition/), citing the policy document itself in back matter. <br>
+
+[Read Tutorial →](policy-component-definition/)
+</div>
+
+<!-- Box containing information about modeling a capability component -->
+<div style="flex: 1 1 300px; border-left: 4px solid #4d8055; background-color: #ecf3ec; padding: 1em; border-radius: 6px;">
+
+<strong>Modeling a Capability Component</strong><br>
+Explore an emerging, proposed pattern for representing an OSCAL capability as a `type="capability"` [component definition](/concepts/layer/implementation/component-definition/) that incorporates other components. <br>
+
+[Read Tutorial →](capability-component-definition/)
+</div>
 </div>

--- a/src/content/learn/tutorials/implementation/capability-component-definition.md
+++ b/src/content/learn/tutorials/implementation/capability-component-definition.md
@@ -1,0 +1,771 @@
+---
+title: Modeling a Capability Component
+date: 2026-07-16 00:00:00 -0400
+description: A tutorial on modeling an OSCAL capability using an emerging, proposed component pattern.
+weight: 60
+suppresstopiclist: true
+toc:
+  enabled: true
+---
+
+This tutorial covers an emerging, proposed pattern for modeling a *capability* as an OSCAL component. Before reading this tutorial you should:
+
+- Have some familiarity with the [XML](https://www.w3.org/standards/xml/core), [JSON](https://www.json.org/), or [YAML](https://yaml.org/spec/) formats.
+- Read the OSCAL implementation layer [overview](/concepts/layer/implementation/).
+- Review the OSCAL [component definition](/concepts/layer/implementation/component-definition/) model overview.
+- Complete the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial, which covers the basic structure, metadata, and control-implementation concepts assumed here.
+
+The OSCAL community is currently discussing a proposed pattern for representing a *capability*: a grouping of multiple components (and/or other capabilities) that together satisfy a control that no single component fully satisfies on its own. This pattern is **not yet part of the published OSCAL schema**. It is a working recommendation still under review, offered here so that authors can become familiar with the concept and provide feedback as the OSCAL community works toward a decision. Everything in this tutorial is illustrative rather than authoritative, and it may change before (or instead of) being adopted.
+
+OSCAL already provides a `<capability>`/`capabilities` element for grouping components within a component definition, as covered in the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial. That element already supports an `incorporates-components` relationship to reference its member components by UUID. However, `<capability>` itself has no equivalent path into the system security plan (SSP) model, so the aggregate relationship it describes can be lost when a component definition's content is imported into an SSP. The proposed pattern addresses this not by inventing a new relationship, but by moving the existing `incorporates-components` relationship onto a `<component>` with `type="capability"` instead of a standalone `<capability>`. Because a capability is then just another `component`, it can be carried into an SSP using the same mechanics already used for any other component, without introducing a parallel model. Only the `type="capability"` placement is proposed here; `incorporates-components` and its required `description` field are part of the current OSCAL schema today.
+
+## Introducing the Member Components
+
+To illustrate this pattern, we'll model a fictional *Centralized Logging* capability built from three AWS services, each of which independently satisfies a different control:
+
+| NIST 800-53 rev5 Control | Description | Component |
+| -------- | -------- | -------- |
+| AU-12 | Audit Record Generation | AWS CloudTrail |
+| AU-5 | Response to Audit Processing Failures | Amazon CloudWatch Logs |
+| AU-11 | Audit Record Retention | Amazon S3 Log Archive |
+
+Each of these is defined as an ordinary `service` component with its own control implementation, just like the MongoDB component in the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial.
+
+{{< tabs XML JSON YAML >}}
+{{% tab %}}
+{{< highlight xml "linenos=table" >}}
+<component uuid="1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d" type="service">
+  <title>AWS CloudTrail</title>
+  <description>
+    <p>AWS CloudTrail records account activity and API calls across AWS
+    infrastructure, providing an event history for auditing and
+    governance.</p>
+  </description>
+  <purpose>Generates an audit trail of account activity</purpose>
+  <control-implementation
+      uuid="4a5b6c7d-6666-4a1b-9c2d-3e4f5a6b7c8d"
+      source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+    <description>
+      <p>CloudTrail control implementations for NIST SP 800-53 revision 5.</p>
+    </description>
+    <implemented-requirement
+        uuid="5b6c7d8e-7777-4b2c-ad3e-4f5a6b7c8d9e"
+        control-id="au-12">
+      <description>
+        <p>CloudTrail generates audit records for management and data
+        events across AWS services, satisfying the requirement to
+        provide audit record generation.</p>
+      </description>
+    </implemented-requirement>
+  </control-implementation>
+</component>
+<component uuid="2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e" type="service">
+  <title>Amazon CloudWatch Logs</title>
+  <description>
+    <p>Amazon CloudWatch Logs centralizes logs from AWS resources,
+    applications, and services for monitoring, storage, and
+    analysis.</p>
+  </description>
+  <purpose>Aggregates and monitors log data from AWS resources</purpose>
+  <control-implementation
+      uuid="6c7d8e9f-8888-4c3d-be4f-5a6b7c8d9e0f"
+      source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+    <description>
+      <p>CloudWatch Logs control implementations for NIST SP 800-53
+      revision 5.</p>
+    </description>
+    <implemented-requirement
+        uuid="7d8e9f0a-9999-4d4e-8f5a-6b7c8d9e0f1a"
+        control-id="au-5">
+      <description>
+        <p>CloudWatch Logs triggers alarms and automated responses when
+        defined metric filters indicate an audit processing failure,
+        satisfying the requirement to respond to audit processing
+        failures.</p>
+      </description>
+    </implemented-requirement>
+  </control-implementation>
+</component>
+<component uuid="3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f" type="service">
+  <title>Amazon S3 Log Archive</title>
+  <description>
+    <p>An Amazon S3 bucket configured with lifecycle and retention
+    policies to durably archive log data for long-term audit record
+    retention.</p>
+  </description>
+  <purpose>Provides long-term, durable storage for archived audit logs</purpose>
+  <control-implementation
+      uuid="8e9f0a1b-aaaa-4e5f-9a6b-7c8d9e0f1a2b"
+      source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+    <description>
+      <p>S3 Log Archive control implementations for NIST SP 800-53
+      revision 5.</p>
+    </description>
+    <implemented-requirement
+        uuid="9f0a1b2c-bbbb-4f6a-ab7c-8d9e0f1a2b3c"
+        control-id="au-11">
+      <description>
+        <p>The S3 Log Archive retains audit records in accordance with
+        the organization-defined retention period, using S3 lifecycle
+        policies to enforce retention and prevent premature
+        deletion.</p>
+      </description>
+    </implemented-requirement>
+  </control-implementation>
+</component>
+{{< /highlight >}}
+
+Each component above is defined the same way the MongoDB component was defined in the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial: a `type="service"` component with its own `<title>`, `<description>`, `<purpose>`, and `<control-implementation>`. Individually, none of these components satisfies **AU-6** (Audit Record Review, Analysis, and Reporting); each only addresses its own, narrower control.
+{{% /tab %}}
+{{% tab %}}
+{{< highlight json "linenos=table" >}}
+{
+  "components": [
+    {
+      "uuid": "1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d",
+      "type": "service",
+      "title": "AWS CloudTrail",
+      "description": "AWS CloudTrail records account activity and API calls across AWS infrastructure, providing an event history for auditing and governance.",
+      "purpose": "Generates an audit trail of account activity",
+      "control-implementations": [{
+        "uuid": "4a5b6c7d-6666-4a1b-9c2d-3e4f5a6b7c8d",
+        "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+        "description": "CloudTrail control implementations for NIST SP 800-53 revision 5.",
+        "implemented-requirements": [{
+          "uuid": "5b6c7d8e-7777-4b2c-ad3e-4f5a6b7c8d9e",
+          "control-id": "au-12",
+          "description": "CloudTrail generates audit records for management and data events across AWS services, satisfying the requirement to provide audit record generation."
+        }]
+      }]
+    },
+    {
+      "uuid": "2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e",
+      "type": "service",
+      "title": "Amazon CloudWatch Logs",
+      "description": "Amazon CloudWatch Logs centralizes logs from AWS resources, applications, and services for monitoring, storage, and analysis.",
+      "purpose": "Aggregates and monitors log data from AWS resources",
+      "control-implementations": [{
+        "uuid": "6c7d8e9f-8888-4c3d-be4f-5a6b7c8d9e0f",
+        "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+        "description": "CloudWatch Logs control implementations for NIST SP 800-53 revision 5.",
+        "implemented-requirements": [{
+          "uuid": "7d8e9f0a-9999-4d4e-8f5a-6b7c8d9e0f1a",
+          "control-id": "au-5",
+          "description": "CloudWatch Logs triggers alarms and automated responses when defined metric filters indicate an audit processing failure, satisfying the requirement to respond to audit processing failures."
+        }]
+      }]
+    },
+    {
+      "uuid": "3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f",
+      "type": "service",
+      "title": "Amazon S3 Log Archive",
+      "description": "An Amazon S3 bucket configured with lifecycle and retention policies to durably archive log data for long-term audit record retention.",
+      "purpose": "Provides long-term, durable storage for archived audit logs",
+      "control-implementations": [{
+        "uuid": "8e9f0a1b-aaaa-4e5f-9a6b-7c8d9e0f1a2b",
+        "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+        "description": "S3 Log Archive control implementations for NIST SP 800-53 revision 5.",
+        "implemented-requirements": [{
+          "uuid": "9f0a1b2c-bbbb-4f6a-ab7c-8d9e0f1a2b3c",
+          "control-id": "au-11",
+          "description": "The S3 Log Archive retains audit records in accordance with the organization-defined retention period, using S3 lifecycle policies to enforce retention and prevent premature deletion."
+        }]
+      }]
+    }
+  ]
+}
+{{< /highlight >}}
+
+Each component above is defined the same way the MongoDB component was defined in the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial: a `service`-typed component with its own `title`, `description`, `purpose`, and `control-implementations`. Individually, none of these components satisfies **AU-6** (Audit Record Review, Analysis, and Reporting); each only addresses its own, narrower control.
+{{% /tab %}}
+{{% tab %}}
+{{< highlight yaml "linenos=table" >}}
+---
+
+components:
+- uuid: 1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d
+  type: service
+  title: AWS CloudTrail
+  description: >-
+    AWS CloudTrail records account activity and API calls across AWS
+    infrastructure, providing an event history for auditing and
+    governance.
+  purpose: Generates an audit trail of account activity
+  control-implementations:
+  - uuid: 4a5b6c7d-6666-4a1b-9c2d-3e4f5a6b7c8d
+    source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+    description: >-
+      CloudTrail control implementations for NIST SP 800-53 revision 5.
+    implemented-requirements:
+    - uuid: 5b6c7d8e-7777-4b2c-ad3e-4f5a6b7c8d9e
+      control-id: au-12
+      description: >-
+        CloudTrail generates audit records for management and data
+        events across AWS services, satisfying the requirement to
+        provide audit record generation.
+- uuid: 2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e
+  type: service
+  title: Amazon CloudWatch Logs
+  description: >-
+    Amazon CloudWatch Logs centralizes logs from AWS resources,
+    applications, and services for monitoring, storage, and analysis.
+  purpose: Aggregates and monitors log data from AWS resources
+  control-implementations:
+  - uuid: 6c7d8e9f-8888-4c3d-be4f-5a6b7c8d9e0f
+    source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+    description: >-
+      CloudWatch Logs control implementations for NIST SP 800-53
+      revision 5.
+    implemented-requirements:
+    - uuid: 7d8e9f0a-9999-4d4e-8f5a-6b7c8d9e0f1a
+      control-id: au-5
+      description: >-
+        CloudWatch Logs triggers alarms and automated responses when
+        defined metric filters indicate an audit processing failure,
+        satisfying the requirement to respond to audit processing
+        failures.
+- uuid: 3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f
+  type: service
+  title: Amazon S3 Log Archive
+  description: >-
+    An Amazon S3 bucket configured with lifecycle and retention
+    policies to durably archive log data for long-term audit record
+    retention.
+  purpose: Provides long-term, durable storage for archived audit logs
+  control-implementations:
+  - uuid: 8e9f0a1b-aaaa-4e5f-9a6b-7c8d9e0f1a2b
+    source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+    description: >-
+      S3 Log Archive control implementations for NIST SP 800-53
+      revision 5.
+    implemented-requirements:
+    - uuid: 9f0a1b2c-bbbb-4f6a-ab7c-8d9e0f1a2b3c
+      control-id: au-11
+      description: >-
+        The S3 Log Archive retains audit records in accordance with
+        the organization-defined retention period, using S3 lifecycle
+        policies to enforce retention and prevent premature deletion.
+{{< /highlight >}}
+
+Each component above is defined the same way the MongoDB component was defined in the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial: a `service`-typed component with its own `title`, `description`, `purpose`, and `control-implementations`. Individually, none of these components satisfies **AU-6** (Audit Record Review, Analysis, and Reporting); each only addresses its own, narrower control.
+{{% /tab %}}
+{{% /tabs %}}
+
+## Defining the Centralized Logging Capability Component
+
+To represent the aggregate relationship between these three components, the proposed pattern defines a fourth component, "Centralized Logging," with `type="capability"`. This capability component uses the existing `incorporates-components` relationship — the same one used by the standalone `<capability>` element — to reference each member component by UUID, and defines its own control implementation showing how the combination of member components satisfies **AU-6**.
+
+{{< tabs XML JSON YAML >}}
+{{% tab %}}
+{{< highlight xml "linenos=table" >}}
+<component uuid="c43f1918-4b40-489a-b7e0-2c6f9a730f5e" type="capability">
+  <title>Centralized Logging</title>
+  <description>
+    <p>The Centralized Logging capability combines account activity
+    recording, log aggregation, and long-term archival to provide
+    comprehensive audit record generation, review, and retention
+    across the system.</p>
+  </description>
+  <purpose>Provides a centralized capability for generating,
+    aggregating, and retaining audit records</purpose>
+  <incorporates-components>
+    <incorporates-component component-uuid="1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d">
+      <description>
+        <p>Generates account activity records consumed by this capability.</p>
+      </description>
+    </incorporates-component>
+    <incorporates-component component-uuid="2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e">
+      <description>
+        <p>Aggregates and monitors the log data collected by this capability.</p>
+      </description>
+    </incorporates-component>
+    <incorporates-component component-uuid="3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f">
+      <description>
+        <p>Retains this capability's audit records for the long term.</p>
+      </description>
+    </incorporates-component>
+  </incorporates-components>
+  <control-implementation
+      uuid="d5e6f7a8-4444-4d8e-bf9a-0b1c2d3e4f5a"
+      source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+    <description>
+      <p>Centralized Logging control implementations for NIST SP
+      800-53 revision 5.</p>
+    </description>
+    <implemented-requirement
+        uuid="e6f7a8b9-5555-4e9f-8a0b-1c2d3e4f5a6b"
+        control-id="au-6">
+      <description>
+        <p>The Centralized Logging capability supports audit record
+        review, analysis, and reporting by combining CloudTrail's
+        account activity records, CloudWatch Logs' aggregation and
+        alerting, and S3 Log Archive's long-term retention into a
+        single, centrally managed logging capability.</p>
+      </description>
+    </implemented-requirement>
+  </control-implementation>
+</component>
+{{< /highlight >}}
+
+This capability component is defined much like any other component, with a `@uuid`, `<title>`, `<description>`, and `<purpose>`. Two things are different:
+
+- The `@type` attribute is set to *"capability"* (line 1) rather than an asset type like *"service"* or *"software"*, marking this component as an aggregation rather than a subject asset in its own right.
+- The `<incorporates-components>` element (line 8) contains one `<incorporates-component>` per member component, each pointing to a member component's `@uuid` via the required `@component-uuid` attribute, along with a required `<description>` of that member's contribution to the capability. This is how the capability declares which components it aggregates.
+
+The capability's own `<control-implementation>` then documents **AU-6**, describing how the combination of CloudTrail, CloudWatch Logs, and S3 Log Archive together satisfies a control that none of them satisfies alone.
+{{% /tab %}}
+{{% tab %}}
+{{< highlight json "linenos=table" >}}
+{
+  "uuid": "c43f1918-4b40-489a-b7e0-2c6f9a730f5e",
+  "type": "capability",
+  "title": "Centralized Logging",
+  "description": "The Centralized Logging capability combines account activity recording, log aggregation, and long-term archival to provide comprehensive audit record generation, review, and retention across the system.",
+  "purpose": "Provides a centralized capability for generating, aggregating, and retaining audit records",
+  "incorporates-components": [
+    {
+      "component-uuid": "1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d",
+      "description": "Generates account activity records consumed by this capability."
+    },
+    {
+      "component-uuid": "2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e",
+      "description": "Aggregates and monitors the log data collected by this capability."
+    },
+    {
+      "component-uuid": "3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f",
+      "description": "Retains this capability's audit records for the long term."
+    }
+  ],
+  "control-implementations": [{
+    "uuid": "d5e6f7a8-4444-4d8e-bf9a-0b1c2d3e4f5a",
+    "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+    "description": "Centralized Logging control implementations for NIST SP 800-53 revision 5.",
+    "implemented-requirements": [{
+      "uuid": "e6f7a8b9-5555-4e9f-8a0b-1c2d3e4f5a6b",
+      "control-id": "au-6",
+      "description": "The Centralized Logging capability supports audit record review, analysis, and reporting by combining CloudTrail's account activity records, CloudWatch Logs' aggregation and alerting, and S3 Log Archive's long-term retention into a single, centrally managed logging capability."
+    }]
+  }]
+}
+{{< /highlight >}}
+
+This capability component is defined much like any other component, with a `uuid`, `title`, `description`, and `purpose`. Two things are different:
+
+- The `type` property is set to *"capability"* (line 3) rather than an asset type like *"service"* or *"software"*, marking this component as an aggregation rather than a subject asset in its own right.
+- The `incorporates-components` array (line 6) contains one object per member component, each pointing to a member component's `uuid` via the required `component-uuid` property, along with a required `description` of that member's contribution to the capability. This is how the capability declares which components it aggregates.
+
+The capability's own `control-implementations` entry then documents **AU-6**, describing how the combination of CloudTrail, CloudWatch Logs, and S3 Log Archive together satisfies a control that none of them satisfies alone.
+{{% /tab %}}
+{{% tab %}}
+{{< highlight yaml "linenos=table" >}}
+---
+
+uuid: c43f1918-4b40-489a-b7e0-2c6f9a730f5e
+type: capability
+title: Centralized Logging
+description: >-
+  The Centralized Logging capability combines account activity
+  recording, log aggregation, and long-term archival to provide
+  comprehensive audit record generation, review, and retention
+  across the system.
+purpose: Provides a centralized capability for generating, aggregating, and retaining audit records
+incorporates-components:
+- component-uuid: 1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d
+  description: Generates account activity records consumed by this capability.
+- component-uuid: 2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e
+  description: Aggregates and monitors the log data collected by this capability.
+- component-uuid: 3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f
+  description: Retains this capability's audit records for the long term.
+control-implementations:
+- uuid: d5e6f7a8-4444-4d8e-bf9a-0b1c2d3e4f5a
+  source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+  description: >-
+    Centralized Logging control implementations for NIST SP 800-53
+    revision 5.
+  implemented-requirements:
+  - uuid: e6f7a8b9-5555-4e9f-8a0b-1c2d3e4f5a6b
+    control-id: au-6
+    description: >-
+      The Centralized Logging capability supports audit record
+      review, analysis, and reporting by combining CloudTrail's
+      account activity records, CloudWatch Logs' aggregation and
+      alerting, and S3 Log Archive's long-term retention into a
+      single, centrally managed logging capability.
+{{< /highlight >}}
+
+This capability component is defined much like any other component, with a `uuid`, `title`, `description`, and `purpose`. Two things are different:
+
+- The `type` key is set to *"capability"* (line 4) rather than an asset type like *"service"* or *"software"*, marking this component as an aggregation rather than a subject asset in its own right.
+- The `incorporates-components` key (line 11) contains one item per member component, each pointing to a member component's `uuid` via the required `component-uuid` key, along with a required `description` of that member's contribution to the capability. This is how the capability declares which components it aggregates.
+
+The capability's own `control-implementations` entry then documents **AU-6**, describing how the combination of CloudTrail, CloudWatch Logs, and S3 Log Archive together satisfies a control that none of them satisfies alone.
+{{% /tab %}}
+{{% /tabs %}}
+
+## The Complete Centralized Logging Example
+
+Combining the member components and the capability component into a single component definition produces the illustrative example below, again reflecting the proposed, not-yet-finalized pattern described in this tutorial.
+
+{{< tabs XML JSON YAML >}}
+{{% tab %}}
+{{< highlight xml "linenos=table" >}}
+
+<?xml version="1.0" encoding="UTF-8"?>
+<component-definition xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    uuid="b21e6d3f-8a1c-4a9e-9f2d-6e7f8a9b0c1d"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_component_schema.xsd">
+  <metadata>
+    <title>Centralized Logging Component Definition Example</title>
+    <last-modified>2024-01-15T09:00:00Z</last-modified>
+    <version>20240115</version>
+    <oscal-version>1.2.2</oscal-version>
+  </metadata>
+  <component uuid="1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d" type="service">
+    <title>AWS CloudTrail</title>
+    <description>
+      <p>AWS CloudTrail records account activity and API calls across AWS
+      infrastructure, providing an event history for auditing and
+      governance.</p>
+    </description>
+    <purpose>Generates an audit trail of account activity</purpose>
+    <control-implementation
+        uuid="4a5b6c7d-6666-4a1b-9c2d-3e4f5a6b7c8d"
+        source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+      <description>
+        <p>CloudTrail control implementations for NIST SP 800-53 revision 5.</p>
+      </description>
+      <implemented-requirement
+          uuid="5b6c7d8e-7777-4b2c-ad3e-4f5a6b7c8d9e"
+          control-id="au-12">
+        <description>
+          <p>CloudTrail generates audit records for management and data
+          events across AWS services, satisfying the requirement to
+          provide audit record generation.</p>
+        </description>
+      </implemented-requirement>
+    </control-implementation>
+  </component>
+  <component uuid="2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e" type="service">
+    <title>Amazon CloudWatch Logs</title>
+    <description>
+      <p>Amazon CloudWatch Logs centralizes logs from AWS resources,
+      applications, and services for monitoring, storage, and
+      analysis.</p>
+    </description>
+    <purpose>Aggregates and monitors log data from AWS resources</purpose>
+    <control-implementation
+        uuid="6c7d8e9f-8888-4c3d-be4f-5a6b7c8d9e0f"
+        source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+      <description>
+        <p>CloudWatch Logs control implementations for NIST SP 800-53
+        revision 5.</p>
+      </description>
+      <implemented-requirement
+          uuid="7d8e9f0a-9999-4d4e-8f5a-6b7c8d9e0f1a"
+          control-id="au-5">
+        <description>
+          <p>CloudWatch Logs triggers alarms and automated responses when
+          defined metric filters indicate an audit processing failure,
+          satisfying the requirement to respond to audit processing
+          failures.</p>
+        </description>
+      </implemented-requirement>
+    </control-implementation>
+  </component>
+  <component uuid="3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f" type="service">
+    <title>Amazon S3 Log Archive</title>
+    <description>
+      <p>An Amazon S3 bucket configured with lifecycle and retention
+      policies to durably archive log data for long-term audit record
+      retention.</p>
+    </description>
+    <purpose>Provides long-term, durable storage for archived audit logs</purpose>
+    <control-implementation
+        uuid="8e9f0a1b-aaaa-4e5f-9a6b-7c8d9e0f1a2b"
+        source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+      <description>
+        <p>S3 Log Archive control implementations for NIST SP 800-53
+        revision 5.</p>
+      </description>
+      <implemented-requirement
+          uuid="9f0a1b2c-bbbb-4f6a-ab7c-8d9e0f1a2b3c"
+          control-id="au-11">
+        <description>
+          <p>The S3 Log Archive retains audit records in accordance with
+          the organization-defined retention period, using S3 lifecycle
+          policies to enforce retention and prevent premature
+          deletion.</p>
+        </description>
+      </implemented-requirement>
+    </control-implementation>
+  </component>
+  <component uuid="c43f1918-4b40-489a-b7e0-2c6f9a730f5e" type="capability">
+    <title>Centralized Logging</title>
+    <description>
+      <p>The Centralized Logging capability combines account activity
+      recording, log aggregation, and long-term archival to provide
+      comprehensive audit record generation, review, and retention
+      across the system.</p>
+    </description>
+    <purpose>Provides a centralized capability for generating,
+      aggregating, and retaining audit records</purpose>
+    <incorporates-components>
+      <incorporates-component component-uuid="1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d">
+        <description>
+          <p>Generates account activity records consumed by this capability.</p>
+        </description>
+      </incorporates-component>
+      <incorporates-component component-uuid="2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e">
+        <description>
+          <p>Aggregates and monitors the log data collected by this capability.</p>
+        </description>
+      </incorporates-component>
+      <incorporates-component component-uuid="3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f">
+        <description>
+          <p>Retains this capability's audit records for the long term.</p>
+        </description>
+      </incorporates-component>
+    </incorporates-components>
+    <control-implementation
+        uuid="d5e6f7a8-4444-4d8e-bf9a-0b1c2d3e4f5a"
+        source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+      <description>
+        <p>Centralized Logging control implementations for NIST SP
+        800-53 revision 5.</p>
+      </description>
+      <implemented-requirement
+          uuid="e6f7a8b9-5555-4e9f-8a0b-1c2d3e4f5a6b"
+          control-id="au-6">
+        <description>
+          <p>The Centralized Logging capability supports audit record
+          review, analysis, and reporting by combining CloudTrail's
+          account activity records, CloudWatch Logs' aggregation and
+          alerting, and S3 Log Archive's long-term retention into a
+          single, centrally managed logging capability.</p>
+        </description>
+      </implemented-requirement>
+    </control-implementation>
+  </component>
+</component-definition>
+{{< /highlight >}}
+{{% /tab %}}
+{{% tab %}}
+{{< highlight json "linenos=table" >}}
+{
+  "component-definition": {
+    "uuid": "b21e6d3f-8a1c-4a9e-9f2d-6e7f8a9b0c1d",
+    "metadata": {
+      "title": "Centralized Logging Component Definition Example",
+      "last-modified": "2024-01-15T09:00:00Z",
+      "version": "20240115",
+      "oscal-version": "1.2.2"
+    },
+    "components": [
+      {
+        "uuid": "1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d",
+        "type": "service",
+        "title": "AWS CloudTrail",
+        "description": "AWS CloudTrail records account activity and API calls across AWS infrastructure, providing an event history for auditing and governance.",
+        "purpose": "Generates an audit trail of account activity",
+        "control-implementations": [{
+          "uuid": "4a5b6c7d-6666-4a1b-9c2d-3e4f5a6b7c8d",
+          "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+          "description": "CloudTrail control implementations for NIST SP 800-53 revision 5.",
+          "implemented-requirements": [{
+            "uuid": "5b6c7d8e-7777-4b2c-ad3e-4f5a6b7c8d9e",
+            "control-id": "au-12",
+            "description": "CloudTrail generates audit records for management and data events across AWS services, satisfying the requirement to provide audit record generation."
+          }]
+        }]
+      },
+      {
+        "uuid": "2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e",
+        "type": "service",
+        "title": "Amazon CloudWatch Logs",
+        "description": "Amazon CloudWatch Logs centralizes logs from AWS resources, applications, and services for monitoring, storage, and analysis.",
+        "purpose": "Aggregates and monitors log data from AWS resources",
+        "control-implementations": [{
+          "uuid": "6c7d8e9f-8888-4c3d-be4f-5a6b7c8d9e0f",
+          "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+          "description": "CloudWatch Logs control implementations for NIST SP 800-53 revision 5.",
+          "implemented-requirements": [{
+            "uuid": "7d8e9f0a-9999-4d4e-8f5a-6b7c8d9e0f1a",
+            "control-id": "au-5",
+            "description": "CloudWatch Logs triggers alarms and automated responses when defined metric filters indicate an audit processing failure, satisfying the requirement to respond to audit processing failures."
+          }]
+        }]
+      },
+      {
+        "uuid": "3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f",
+        "type": "service",
+        "title": "Amazon S3 Log Archive",
+        "description": "An Amazon S3 bucket configured with lifecycle and retention policies to durably archive log data for long-term audit record retention.",
+        "purpose": "Provides long-term, durable storage for archived audit logs",
+        "control-implementations": [{
+          "uuid": "8e9f0a1b-aaaa-4e5f-9a6b-7c8d9e0f1a2b",
+          "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+          "description": "S3 Log Archive control implementations for NIST SP 800-53 revision 5.",
+          "implemented-requirements": [{
+            "uuid": "9f0a1b2c-bbbb-4f6a-ab7c-8d9e0f1a2b3c",
+            "control-id": "au-11",
+            "description": "The S3 Log Archive retains audit records in accordance with the organization-defined retention period, using S3 lifecycle policies to enforce retention and prevent premature deletion."
+          }]
+        }]
+      },
+      {
+        "uuid": "c43f1918-4b40-489a-b7e0-2c6f9a730f5e",
+        "type": "capability",
+        "title": "Centralized Logging",
+        "description": "The Centralized Logging capability combines account activity recording, log aggregation, and long-term archival to provide comprehensive audit record generation, review, and retention across the system.",
+        "purpose": "Provides a centralized capability for generating, aggregating, and retaining audit records",
+        "incorporates-components": [
+          {
+            "component-uuid": "1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d",
+            "description": "Generates account activity records consumed by this capability."
+          },
+          {
+            "component-uuid": "2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e",
+            "description": "Aggregates and monitors the log data collected by this capability."
+          },
+          {
+            "component-uuid": "3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f",
+            "description": "Retains this capability's audit records for the long term."
+          }
+        ],
+        "control-implementations": [{
+          "uuid": "d5e6f7a8-4444-4d8e-bf9a-0b1c2d3e4f5a",
+          "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+          "description": "Centralized Logging control implementations for NIST SP 800-53 revision 5.",
+          "implemented-requirements": [{
+            "uuid": "e6f7a8b9-5555-4e9f-8a0b-1c2d3e4f5a6b",
+            "control-id": "au-6",
+            "description": "The Centralized Logging capability supports audit record review, analysis, and reporting by combining CloudTrail's account activity records, CloudWatch Logs' aggregation and alerting, and S3 Log Archive's long-term retention into a single, centrally managed logging capability."
+          }]
+        }]
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+{{% /tab %}}
+{{% tab %}}
+{{< highlight yaml "linenos=table" >}}
+---
+component-definition:
+  uuid: b21e6d3f-8a1c-4a9e-9f2d-6e7f8a9b0c1d
+  metadata:
+    title: Centralized Logging Component Definition Example
+    last-modified: '2024-01-15T09:00:00Z'
+    version: '20240115'
+    oscal-version: '1.2.2'
+  components:
+  - uuid: 1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d
+    type: service
+    title: AWS CloudTrail
+    description: >-
+      AWS CloudTrail records account activity and API calls across AWS
+      infrastructure, providing an event history for auditing and
+      governance.
+    purpose: Generates an audit trail of account activity
+    control-implementations:
+    - uuid: 4a5b6c7d-6666-4a1b-9c2d-3e4f5a6b7c8d
+      source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+      description: >-
+        CloudTrail control implementations for NIST SP 800-53 revision 5.
+      implemented-requirements:
+      - uuid: 5b6c7d8e-7777-4b2c-ad3e-4f5a6b7c8d9e
+        control-id: au-12
+        description: >-
+          CloudTrail generates audit records for management and data
+          events across AWS services, satisfying the requirement to
+          provide audit record generation.
+  - uuid: 2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e
+    type: service
+    title: Amazon CloudWatch Logs
+    description: >-
+      Amazon CloudWatch Logs centralizes logs from AWS resources,
+      applications, and services for monitoring, storage, and analysis.
+    purpose: Aggregates and monitors log data from AWS resources
+    control-implementations:
+    - uuid: 6c7d8e9f-8888-4c3d-be4f-5a6b7c8d9e0f
+      source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+      description: >-
+        CloudWatch Logs control implementations for NIST SP 800-53
+        revision 5.
+      implemented-requirements:
+      - uuid: 7d8e9f0a-9999-4d4e-8f5a-6b7c8d9e0f1a
+        control-id: au-5
+        description: >-
+          CloudWatch Logs triggers alarms and automated responses when
+          defined metric filters indicate an audit processing failure,
+          satisfying the requirement to respond to audit processing
+          failures.
+  - uuid: 3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f
+    type: service
+    title: Amazon S3 Log Archive
+    description: >-
+      An Amazon S3 bucket configured with lifecycle and retention
+      policies to durably archive log data for long-term audit record
+      retention.
+    purpose: Provides long-term, durable storage for archived audit logs
+    control-implementations:
+    - uuid: 8e9f0a1b-aaaa-4e5f-9a6b-7c8d9e0f1a2b
+      source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+      description: >-
+        S3 Log Archive control implementations for NIST SP 800-53
+        revision 5.
+      implemented-requirements:
+      - uuid: 9f0a1b2c-bbbb-4f6a-ab7c-8d9e0f1a2b3c
+        control-id: au-11
+        description: >-
+          The S3 Log Archive retains audit records in accordance with
+          the organization-defined retention period, using S3 lifecycle
+          policies to enforce retention and prevent premature deletion.
+  - uuid: c43f1918-4b40-489a-b7e0-2c6f9a730f5e
+    type: capability
+    title: Centralized Logging
+    description: >-
+      The Centralized Logging capability combines account activity
+      recording, log aggregation, and long-term archival to provide
+      comprehensive audit record generation, review, and retention
+      across the system.
+    purpose: Provides a centralized capability for generating, aggregating, and retaining audit records
+    incorporates-components:
+    - component-uuid: 1a2b3c4d-1111-4a5b-8c6d-7e8f9a0b1c2d
+      description: Generates account activity records consumed by this capability.
+    - component-uuid: 2b3c4d5e-2222-4b6c-9d7e-8f9a0b1c2d3e
+      description: Aggregates and monitors the log data collected by this capability.
+    - component-uuid: 3c4d5e6f-3333-4c7d-ae8f-9a0b1c2d3e4f
+      description: Retains this capability's audit records for the long term.
+    control-implementations:
+    - uuid: d5e6f7a8-4444-4d8e-bf9a-0b1c2d3e4f5a
+      source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+      description: >-
+        Centralized Logging control implementations for NIST SP 800-53
+        revision 5.
+      implemented-requirements:
+      - uuid: e6f7a8b9-5555-4e9f-8a0b-1c2d3e4f5a6b
+        control-id: au-6
+        description: >-
+          The Centralized Logging capability supports audit record
+          review, analysis, and reporting by combining CloudTrail's
+          account activity records, CloudWatch Logs' aggregation and
+          alerting, and S3 Log Archive's long-term retention into a
+          single, centrally managed logging capability.
+{{< /highlight >}}
+{{% /tab %}}
+{{% /tabs %}}
+
+As a reminder, applying `type="capability"` to a `<component>` is **not part of the current OSCAL schema**. It represents a pattern proposed to the OSCAL community that is still under discussion and may change, be revised, or not be adopted at all. (`incorporates-components` itself is not new — it's the existing relationship already used by the standalone `<capability>` element, simply moved onto a component.) The existing `<capability>`/`capabilities` element covered in the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial remains the current, supported way to group components within a component definition today. Readers interested in this proposal are encouraged to follow and participate in the OSCAL community's discussion as it develops.
+
+## Summary
+
+This concludes the tutorial.  You should now be familiar with:
+
+- The proposed pattern for representing an OSCAL capability using a component with `type="capability"`, which is not yet part of the OSCAL schema.
+- How to define member components that each independently satisfy their own control.
+- How to use the existing `incorporates-components` relationship to reference member components, including its required per-member `description`.
+- How this pattern is intended to carry capability information into a system security plan using the same mechanics already used for any other component.
+
+For more information, you can review the OSCAL component definition model [documentation](/concepts/layer/implementation/component-definition/).

--- a/src/content/learn/tutorials/implementation/policy-component-definition.md
+++ b/src/content/learn/tutorials/implementation/policy-component-definition.md
@@ -1,0 +1,390 @@
+---
+title: Creating a Policy Component
+date: 2026-07-16 00:00:00 -0400
+description: A tutorial on creating an OSCAL component definition for an organizational policy.
+weight: 50
+suppresstopiclist: true
+toc:
+  enabled: true
+---
+
+This tutorial covers creating an OSCAL component that represents an organizational **policy**, rather than a piece of software or a service. Before reading this tutorial you should:
+
+- Have some familiarity with the [XML](https://www.w3.org/standards/xml/core), [JSON](https://www.json.org/), or [YAML](https://yaml.org/spec/) formats.
+- Read the OSCAL implementation layer [overview](/concepts/layer/implementation/).
+- Review the OSCAL [component definition](/concepts/layer/implementation/component-definition/) model overview.
+- Complete the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial, which covers the basic structure, metadata, and control-implementation concepts assumed here.
+
+Not every component represents a product or service. Policy owners, process owners, and standards bodies can use OSCAL component definitions to document how an organizational policy or procedure satisfies one or more controls. This tutorial models a fictional **Incident Response Policy** as a `type="policy"` component satisfying **IR-1** (Incident Response Policy and Procedures) — a natural fit, since IR-1 and the other `-1` controls in NIST SP 800-53 specifically require organizations to develop, document, and disseminate a policy.
+
+## Defining the Incident Response Policy Component
+
+A policy component is defined the same way as any other component — with a `uuid`, `title`, `description`, and `purpose` — but with two differences from the MongoDB component in the [Creating a Component Definition](/learn/tutorials/implementation/simple-component-definition/) tutorial: its `type` is set to *"policy"*, and it has no protocols, since a policy component doesn't expose network services. Instead, a policy component typically points to the actual policy document itself, cited as a back-matter resource.
+
+{{< tabs XML JSON YAML >}}
+{{% tab %}}
+{{< highlight xml "linenos=table" >}}
+<component uuid="f1a2b3c4-5d6e-4f70-8a9b-0c1d2e3f4a5b" type="policy">
+  <title>Incident Response Policy</title>
+  <description>
+    <p>The Incident Response Policy establishes organizational
+    requirements for preparing for, detecting, analyzing,
+    containing, and recovering from information security
+    incidents.</p>
+  </description>
+  <purpose>Documents organizational incident response policy and procedures</purpose>
+  <link rel="reference" href="#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d"/>
+</component>
+{{< /highlight >}}
+
+- The `@type` attribute is set to *"policy"* (line 1), marking this component as an organizational document rather than a product or service.
+- The `<description>` and `<purpose>` (lines 3–8) describe what the policy governs, not a product's technical function.
+- The `<link>` element (line 9) has `@rel="reference"` and an `@href` of `#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d` — a fragment identifier pointing to a resource defined in this component definition's `<back-matter>`. This is how a component cites the actual policy document it represents, as shown below.
+{{% /tab %}}
+{{% tab %}}
+{{< highlight json "linenos=table" >}}
+{
+  "uuid": "f1a2b3c4-5d6e-4f70-8a9b-0c1d2e3f4a5b",
+  "type": "policy",
+  "title": "Incident Response Policy",
+  "description": "The Incident Response Policy establishes organizational requirements for preparing for, detecting, analyzing, containing, and recovering from information security incidents.",
+  "purpose": "Documents organizational incident response policy and procedures",
+  "links": [
+    {
+      "href": "#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d",
+      "rel": "reference"
+    }
+  ]
+}
+{{< /highlight >}}
+
+- The `type` property is set to *"policy"* (line 3), marking this component as an organizational document rather than a product or service.
+- The `description` and `purpose` (lines 4–5) describe what the policy governs, not a product's technical function.
+- The `links` array (lines 6–11) contains an object with `rel: "reference"` and an `href` of `#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d` — a fragment identifier pointing to a resource defined in this component definition's `back-matter`. This is how a component cites the actual policy document it represents, as shown below.
+{{% /tab %}}
+{{% tab %}}
+{{< highlight yaml "linenos=table" >}}
+---
+
+uuid: f1a2b3c4-5d6e-4f70-8a9b-0c1d2e3f4a5b
+type: policy
+title: Incident Response Policy
+description: >-
+  The Incident Response Policy establishes organizational requirements
+  for preparing for, detecting, analyzing, containing, and recovering
+  from information security incidents.
+purpose: Documents organizational incident response policy and procedures
+links:
+- href: '#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d'
+  rel: reference
+{{< /highlight >}}
+
+- The `type` key is set to *"policy"* (line 4), marking this component as an organizational document rather than a product or service.
+- The `description` and `purpose` (lines 5–9) describe what the policy governs, not a product's technical function.
+- The `links` key (lines 10–12) contains an item with `rel: reference` and an `href` of `#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d` — a fragment identifier pointing to a resource defined in this component definition's `back-matter`. This is how a component cites the actual policy document it represents, as shown below.
+{{% /tab %}}
+{{% /tabs %}}
+
+## Citing the Policy Document in Back Matter
+
+`back-matter` is a syntax shared by all OSCAL models for describing attachments, citations, and other resources referenced from elsewhere in a document. Here, it's used to cite the actual Incident Response Policy document, an external artifact the component represents rather than replaces.
+
+{{< tabs XML JSON YAML >}}
+{{% tab %}}
+{{< highlight xml "linenos=table" >}}
+<back-matter>
+  <resource uuid="a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d">
+    <title>Incident Response Policy Document</title>
+    <rlink href="https://example.com/policies/incident-response-policy.pdf" media-type="application/pdf"/>
+  </resource>
+</back-matter>
+{{< /highlight >}}
+
+The `<resource>` element (line 2) has a `@uuid` matching the fragment identifier referenced by the component's `<link>` above, a `<title>` (line 3), and an `<rlink>` (line 4) providing the actual `@href` to the policy document and its `@media-type`.
+{{% /tab %}}
+{{% tab %}}
+{{< highlight json "linenos=table" >}}
+{
+  "back-matter": {
+    "resources": [
+      {
+        "uuid": "a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d",
+        "title": "Incident Response Policy Document",
+        "rlinks": [
+          {
+            "href": "https://example.com/policies/incident-response-policy.pdf",
+            "media-type": "application/pdf"
+          }
+        ]
+      }
+    ]
+  }
+}
+{{< /highlight >}}
+
+The `resource` object (lines 4–12) has a `uuid` matching the fragment identifier referenced by the component's `links` above, a `title` (line 6), and an `rlinks` array (lines 7–12) providing the actual `href` to the policy document and its `media-type`.
+{{% /tab %}}
+{{% tab %}}
+{{< highlight yaml "linenos=table" >}}
+---
+
+back-matter:
+  resources:
+  - uuid: a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d
+    title: Incident Response Policy Document
+    rlinks:
+    - href: <https://example.com/policies/incident-response-policy.pdf>
+      media-type: application/pdf
+{{< /highlight >}}
+
+The `resource` item (lines 4–8) has a `uuid` matching the fragment identifier referenced by the component's `links` above, a `title` (line 5), and an `rlinks` key (lines 6–8) providing the actual `href` to the policy document and its `media-type`.
+{{% /tab %}}
+{{% /tabs %}}
+
+## Defining Control Implementation Details
+
+The policy component's control implementation documents how the policy itself satisfies **IR-1**: not by performing an action, but by existing, being disseminated, and being kept current.
+
+{{< tabs XML JSON YAML >}}
+{{% tab %}}
+{{< highlight xml "linenos=table" >}}
+<control-implementation
+    uuid="b2c3d4e5-2345-4b6c-9d7e-8f9a0b1c2d3e"
+    source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+  <description>
+    <p>Incident Response Policy control implementations for NIST SP
+    800-53 revision 5.</p>
+  </description>
+  <implemented-requirement
+      uuid="c3d4e5f6-3456-4c7d-ae8f-9a0b1c2d3e4f"
+      control-id="ir-1">
+    <description>
+      <p>The organization's Incident Response Policy, cited in back
+      matter, documents the purpose, scope, roles, responsibilities,
+      and coordination among organizational entities for incident
+      response, and is reviewed and updated annually, satisfying the
+      requirement to develop, document, and disseminate an incident
+      response policy.</p>
+    </description>
+  </implemented-requirement>
+</control-implementation>
+{{< /highlight >}}
+{{% /tab %}}
+{{% tab %}}
+{{< highlight json "linenos=table" >}}
+{
+  "control-implementations": [
+    {
+      "uuid": "b2c3d4e5-2345-4b6c-9d7e-8f9a0b1c2d3e",
+      "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+      "description": "Incident Response Policy control implementations for NIST SP 800-53 revision 5.",
+      "implemented-requirements": [
+        {
+          "uuid": "c3d4e5f6-3456-4c7d-ae8f-9a0b1c2d3e4f",
+          "control-id": "ir-1",
+          "description": "The organization's Incident Response Policy, cited in back matter, documents the purpose, scope, roles, responsibilities, and coordination among organizational entities for incident response, and is reviewed and updated annually, satisfying the requirement to develop, document, and disseminate an incident response policy."
+        }
+      ]
+    }
+  ]
+}
+{{< /highlight >}}
+{{% /tab %}}
+{{% tab %}}
+{{< highlight yaml "linenos=table" >}}
+---
+
+control-implementations:
+- uuid: b2c3d4e5-2345-4b6c-9d7e-8f9a0b1c2d3e
+  source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+  description: >-
+    Incident Response Policy control implementations for NIST SP
+    800-53 revision 5.
+  implemented-requirements:
+  - uuid: c3d4e5f6-3456-4c7d-ae8f-9a0b1c2d3e4f
+    control-id: ir-1
+    description: >-
+      The organization's Incident Response Policy, cited in back
+      matter, documents the purpose, scope, roles, responsibilities,
+      and coordination among organizational entities for incident
+      response, and is reviewed and updated annually, satisfying the
+      requirement to develop, document, and disseminate an incident
+      response policy.
+{{< /highlight >}}
+{{% /tab %}}
+{{% /tabs %}}
+
+## The Final Component Definition
+
+Combining the policy component, its back-matter citation, and its control implementation into a single component definition produces the example below.
+
+{{< tabs XML JSON YAML >}}
+{{% tab %}}
+{{< highlight xml "linenos=table" >}}
+<?xml version="1.0" encoding="UTF-8"?>
+<component-definition xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    uuid="d4e5f6a7-4567-4d8e-bf9a-0b1c2d3e4f5a"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/1.0 https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_component_schema.xsd">
+  <metadata>
+    <title>Incident Response Policy Component Definition Example</title>
+    <last-modified>2024-01-15T09:00:00Z</last-modified>
+    <version>20240115</version>
+    <oscal-version>1.2.2</oscal-version>
+  </metadata>
+  <component uuid="f1a2b3c4-5d6e-4f70-8a9b-0c1d2e3f4a5b" type="policy">
+    <title>Incident Response Policy</title>
+    <description>
+      <p>The Incident Response Policy establishes organizational
+      requirements for preparing for, detecting, analyzing,
+      containing, and recovering from information security
+      incidents.</p>
+    </description>
+    <purpose>Documents organizational incident response policy and procedures</purpose>
+    <link rel="reference" href="#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d"/>
+    <control-implementation
+        uuid="b2c3d4e5-2345-4b6c-9d7e-8f9a0b1c2d3e"
+        source="https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_MODERATE-baseline_profile.xml">
+      <description>
+        <p>Incident Response Policy control implementations for NIST SP
+        800-53 revision 5.</p>
+      </description>
+      <implemented-requirement
+          uuid="c3d4e5f6-3456-4c7d-ae8f-9a0b1c2d3e4f"
+          control-id="ir-1">
+        <description>
+          <p>The organization's Incident Response Policy, cited in back
+          matter, documents the purpose, scope, roles, responsibilities,
+          and coordination among organizational entities for incident
+          response, and is reviewed and updated annually, satisfying the
+          requirement to develop, document, and disseminate an incident
+          response policy.</p>
+        </description>
+      </implemented-requirement>
+    </control-implementation>
+  </component>
+  <back-matter>
+    <resource uuid="a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d">
+      <title>Incident Response Policy Document</title>
+      <rlink href="https://example.com/policies/incident-response-policy.pdf" media-type="application/pdf"/>
+    </resource>
+  </back-matter>
+</component-definition>
+{{< /highlight >}}
+{{% /tab %}}
+{{% tab %}}
+{{< highlight json "linenos=table" >}}
+{
+  "component-definition": {
+    "uuid": "d4e5f6a7-4567-4d8e-bf9a-0b1c2d3e4f5a",
+    "metadata": {
+      "title": "Incident Response Policy Component Definition Example",
+      "last-modified": "2024-01-15T09:00:00Z",
+      "version": "20240115",
+      "oscal-version": "1.2.2"
+    },
+    "components": [
+      {
+        "uuid": "f1a2b3c4-5d6e-4f70-8a9b-0c1d2e3f4a5b",
+        "type": "policy",
+        "title": "Incident Response Policy",
+        "description": "The Incident Response Policy establishes organizational requirements for preparing for, detecting, analyzing, containing, and recovering from information security incidents.",
+        "purpose": "Documents organizational incident response policy and procedures",
+        "links": [
+          {
+            "href": "#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d",
+            "rel": "reference"
+          }
+        ],
+        "control-implementations": [
+          {
+            "uuid": "b2c3d4e5-2345-4b6c-9d7e-8f9a0b1c2d3e",
+            "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
+            "description": "Incident Response Policy control implementations for NIST SP 800-53 revision 5.",
+            "implemented-requirements": [
+              {
+                "uuid": "c3d4e5f6-3456-4c7d-ae8f-9a0b1c2d3e4f",
+                "control-id": "ir-1",
+                "description": "The organization's Incident Response Policy, cited in back matter, documents the purpose, scope, roles, responsibilities, and coordination among organizational entities for incident response, and is reviewed and updated annually, satisfying the requirement to develop, document, and disseminate an incident response policy."
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "back-matter": {
+      "resources": [
+        {
+          "uuid": "a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d",
+          "title": "Incident Response Policy Document",
+          "rlinks": [
+            {
+              "href": "https://example.com/policies/incident-response-policy.pdf",
+              "media-type": "application/pdf"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+{{< /highlight >}}
+{{% /tab %}}
+{{% tab %}}
+{{< highlight yaml "linenos=table" >}}
+---
+component-definition:
+  uuid: d4e5f6a7-4567-4d8e-bf9a-0b1c2d3e4f5a
+  metadata:
+    title: Incident Response Policy Component Definition Example
+    last-modified: '2024-01-15T09:00:00Z'
+    version: '20240115'
+    oscal-version: '1.2.2'
+  components:
+  - uuid: f1a2b3c4-5d6e-4f70-8a9b-0c1d2e3f4a5b
+    type: policy
+    title: Incident Response Policy
+    description: >-
+      The Incident Response Policy establishes organizational requirements
+      for preparing for, detecting, analyzing, containing, and recovering
+      from information security incidents.
+    purpose: Documents organizational incident response policy and procedures
+    links:
+    - href: '#a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d'
+      rel: reference
+    control-implementations:
+    - uuid: b2c3d4e5-2345-4b6c-9d7e-8f9a0b1c2d3e
+      source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
+      description: >-
+        Incident Response Policy control implementations for NIST SP
+        800-53 revision 5.
+      implemented-requirements:
+      - uuid: c3d4e5f6-3456-4c7d-ae8f-9a0b1c2d3e4f
+        control-id: ir-1
+        description: >-
+          The organization's Incident Response Policy, cited in back
+          matter, documents the purpose, scope, roles, responsibilities,
+          and coordination among organizational entities for incident
+          response, and is reviewed and updated annually, satisfying the
+          requirement to develop, document, and disseminate an incident
+          response policy.
+  back-matter:
+    resources:
+    - uuid: a1b2c3d4-1234-4a5b-8c6d-7e8f9a0b1c2d
+      title: Incident Response Policy Document
+      rlinks:
+      - href: <https://example.com/policies/incident-response-policy.pdf>
+        media-type: application/pdf
+{{< /highlight >}}
+{{% /tab %}}
+{{% /tabs %}}
+
+## Summary
+
+This concludes the tutorial.  You should now be familiar with:
+
+- How a `type="policy"` component differs from a software or service component.
+- How to cite an external policy document as a `back-matter` resource and reference it from a component using a `link`.
+- How to specify a control implementation showing how a policy satisfies a control.
+
+For more information, you can review the OSCAL component definition model [documentation](/concepts/layer/implementation/component-definition/).

--- a/src/content/learn/tutorials/implementation/simple-component-definition.md
+++ b/src/content/learn/tutorials/implementation/simple-component-definition.md
@@ -63,7 +63,7 @@ A `<component-definition>` contains the following elements:
 - `<metadata>` (required) - Provides document metadata for the component definition. This is covered in the [next section](#defining-the-component-definitions-metadata) to a limited extent. The metadata used here is similar to metadata for other OSCAL models, therefor is not described extensively in this tutorial.
 - `<import-component-definition>` (optional) – Identifies a collection of external component definitions from other resources from which related information is referenced within this component definition. Use of `<import-component-definition>` is not covered in this tutorial.
 - `<component>` (optional) - Defines a given component in the component definition. Zero or more `<component>` elements may be used. Use of this element is [discussed later](#defining-the-mongodb-component) in this tutorial.
-- `<capability>` (optional) - Defines a given capability in the component definition. Zero or more `<capability>` elements may be used. Capabilities are not covered in this tutorial.
+- `<capability>` (optional) - Defines a given capability in the component definition. Zero or more `<capability>` elements may be used. This tutorial does not cover the `<capability>` element directly, but see [Modeling a Capability Component](/learn/tutorials/implementation/capability-component-definition/) for an emerging, proposed alternative pattern for representing capabilities using `<component>`.
 - `<back-matter>` (optional) – Contains resources which are referenced within the component definition. Use of `<back-matter>` is not covered in this tutorial.
 {{% /tab %}}
 {{% tab %}}
@@ -87,7 +87,7 @@ A `component-definition` contains the following properties:
 - `metadata` (required) - Provides document metadata for the component definition. This is covered in the [next section](#defining-the-component-definitions-metadata) to a limited extent. The metadata used here is similar to metadata for other OSCAL models, therefor is not described extensively in this tutorial.
 - `import-component-definitions` (optional) – Identifies a collection of external component definitions from other resources from which related information is referenced within this component definition.  Use of `import-component-definitions` is not covered in this tutorial.
 - `components` (optional) - Groups `component` objects which each define a given component in the component definition. One or more `component` objects may be provided. Use of this property is [discussed later](#defining-the-mongodb-component) in this tutorial.
-- `capabilities` (optional) - Defines a group of given capabilities in the component definition. One or more `capability` objects may be used. Capabilities are not covered in this tutorial.
+- `capabilities` (optional) - Defines a group of given capabilities in the component definition. One or more `capability` objects may be used. This tutorial does not cover the `capabilities` key directly, but see [Modeling a Capability Component](/learn/tutorials/implementation/capability-component-definition/) for an emerging, proposed alternative pattern for representing capabilities using `components`.
 - `back-matter` (optional) – Contains references which are referenced within the component definition. Use of `back-matter` is not covered in this tutorial.
 {{% /tab %}}
 {{% tab %}}
@@ -110,7 +110,7 @@ A `component-definition` contains the following keys:
 - `metadata` (required) - Provides document metadata for the component definition. This is covered in the [next section](#defining-the-component-definitions-metadata) to a limited extent. The metadata used here is similar to metadata for other OSCAL models, therefor is not described extensively in this tutorial.
 - `import-component-definitions` (optional) – Identifies a collection of external component definitions from other resources from which related information is referenced within this component definition.  Use of `import-component-definitions` is not covered in this tutorial.
 - `components` (optional) - Groups `component` items which define given component(s) in the component definition. One or more `component` items may be used. Use of this key is [discussed later](#defining-the-mongodb-component) in this tutorial.
-- `capabilities` (optional) - Defines a group of given capabilities in the component definition. One or more `capability` items may be used. Capabilities are not covered in this tutorial.
+- `capabilities` (optional) - Defines a group of given capabilities in the component definition. One or more `capability` items may be used. This tutorial does not cover the `capabilities` key directly, but see [Modeling a Capability Component](/learn/tutorials/implementation/capability-component-definition/) for an emerging, proposed alternative pattern for representing capabilities using `components`.
 - `back-matter` (optional) – Contains references which are referenced within the component definition. Use of `back-matter` is not covered in this tutorial.
 {{% /tab %}}
 {{< /tabs >}}
@@ -130,7 +130,7 @@ Most OSCAL models have a standard metadata syntax, therefore, this is not covere
     <title>MongoDB Component Definition Example</title>
     <last-modified>2001-08-26T23:11:47Z</last-modified>
     <version>20210826</version>
-    <oscal-version>1.0.0</oscal-version>
+    <oscal-version>1.2.2</oscal-version>
     <role id="provider">
       <title>Provider</title>
     </role>
@@ -154,8 +154,8 @@ The `<party>` element represents either a person or organization that serves as 
     "metadata": {
       "title": "MongoDB Component Definition Example",
       "last-modified": "2001-12-17T09:30:47Z",
-      "version": 20210507,
-      "oscal-version": "1.0.0",
+      "version": "20210507",
+      "oscal-version": "1.2.2",
       "roles": [{
         "id": "provider",
         "title": "Provider"
@@ -188,8 +188,8 @@ component-definition:
   metadata:
     title: MongoDB Component Definition Example
     last-modified: '2001-12-17T09:30:47Z'
-    version: 20210507
-    oscal-version: 1.0.0
+    version: '20210507'
+    oscal-version: '1.2.2'
     roles:
     - id: provider
       title: Provider
@@ -254,7 +254,7 @@ The optional `<responsible-role>` element can be used to reference one or more r
       "purpose": "Provides a NoSQL database service",
       "responsible-roles": [{
         "role-id": "provider",
-        "party-uuid": "ef7c799a-c50e-49ab-83e0-515e989e6df1"
+        "party-uuids": ["ef7c799a-c50e-49ab-83e0-515e989e6df1"]
       }],
       "protocols": [{}],
       "control-implementations": [{}]
@@ -288,7 +288,8 @@ component-definition:
     purpose: Provides a NoSQL database service
     responsible-roles:
     - role-id: provider
-      party-uuid: ef7c799a-c50e-49ab-83e0-515e989e6df1
+      party-uuids:
+      - ef7c799a-c50e-49ab-83e0-515e989e6df1
     protocols: ~
     control-implementations: ~
 {{< /highlight >}}
@@ -475,16 +476,11 @@ In the example above, we demonstrated how to use OSCAL to document the MongoDB s
       "control-implementations": [{
         "uuid": "49f0b690-ed9f-4f32-aae0-625b77aa6d27",
         "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
-        "description": "MongoDB control implementations for NIST SP 800-53
-          revision 5.",
-        "implemented-requirements" [{
+        "description": "MongoDB control implementations for NIST SP 800-53 revision 5.",
+        "implemented-requirements": [{
           "uuid": "cf8338c5-fb6e-4593-a4a8-b3c4946ee2a0",
           "control-id": "sc-8.1",
-          "description": "MongoDB supports TLS 1.x to encrypt data in transit,
-            preventing unauthorized disclosure or changes to information
-            during transmission. To implement TLS, set the PEMKeyFile option
-            in the configuration file /etc/mongod.conf to the certificate
-            file's path and restart the the component."
+          "description": "MongoDB supports TLS 1.x to encrypt data in transit, preventing unauthorized disclosure or changes to information during transmission. To implement TLS, set the PEMKeyFile option in the configuration file /etc/mongod.conf to the certificate file's path and restart the the component."
         }]
       }]
     }]
@@ -502,7 +498,7 @@ In the example above, we demonstrated how to use OSCAL to document the MongoDB s
 ---
 
 component-definition:
-  uuid: a7ba800c-a432-44cd-9075-0862cd66da6b,
+  uuid: a7ba800c-a432-44cd-9075-0862cd66da6b
   components:
   - uuid: 91f646c5-b1b6-4786-9ec3-2305a044e217
     type: software
@@ -510,7 +506,8 @@ component-definition:
     - uuid: 49f0b690-ed9f-4f32-aae0-625b77aa6d27
       source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
       description: >-
-        MongoDB control implementations for NIST SP 800-53rev5.
+        MongoDB control implementations for NIST SP 800-53
+        revision 5.
       implemented-requirements:
       - uuid: cf8338c5-fb6e-4593-a4a8-b3c4946ee2a0
         control-id: sc-8.1
@@ -547,7 +544,7 @@ and [YAML]({{< param "contentRepoPath" >}}/examples/component-definition/yaml/ex
     <title>MongoDB Component Definition Example</title>
     <last-modified>2001-08-26T23:11:47Z</last-modified>
     <version>20210826</version>
-    <oscal-version>1.0.0</oscal-version>
+    <oscal-version>1.2.2</oscal-version>
     <role id="provider">
       <title>Provider</title>
     </role>
@@ -599,7 +596,7 @@ and [YAML]({{< param "contentRepoPath" >}}/examples/component-definition/yaml/ex
         </description>
       </implemented-requirement>
       <implemented-requirement
-          uuid="cf8338c5-fb6e-4593-a4a8-b3c4946ee2a0"
+          uuid="d1e2f3a4-b5c6-4d7e-8f9a-0b1c2d3e4f5a"
           control-id="sa-4.9">
         <description>
           <p>Must ensure that MongoDB only listens for network
@@ -622,17 +619,20 @@ and [YAML]({{< param "contentRepoPath" >}}/examples/component-definition/yaml/ex
     "metadata": {
       "title": "MongoDB Component Definition Example",
       "last-modified": "2001-12-17T09:30:47Z",
-      "version": 20210507,
-      "oscal-version": "1.0.0",
+      "version": "20210507",
+      "oscal-version": "1.2.2",
       "roles": [{
-      "id": "supplier",
-      "title": "Supplier"
+      "id": "provider",
+      "title": "Provider"
       }],
       "parties": [{
       "uuid": "ef7c799a-c50e-49ab-83e0-515e989e6df1",
       "type": "organization",
       "name": "MongoDB",
-      "links": "https://www.mongodb.com"
+      "links": [{
+        "href": "https://www.mongodb.com",
+        "rel": "website"
+      }]
       }]
     },
     "components": [{
@@ -643,7 +643,7 @@ and [YAML]({{< param "contentRepoPath" >}}/examples/component-definition/yaml/ex
       "purpose": "Provides a NoSQL database service",
       "responsible-roles": [{
         "role-id": "provider",
-        "party-uuid": "ef7c799a-c50e-49ab-83e0-515e989e6df1"
+        "party-uuids": ["ef7c799a-c50e-49ab-83e0-515e989e6df1"]
       }],
       "protocols": [{
         "uuid": "2b4a1b3a-cbc5-4cc8-bde6-7437c28c4e54",
@@ -678,16 +678,16 @@ and [YAML]({{< param "contentRepoPath" >}}/examples/component-definition/yaml/ex
       "control-implementations": [{
         "uuid": "49f0b690-ed9f-4f32-aae0-625b77aa6d27",
         "source": "https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json",
-        "description": "MongoDB control implementations for NIST SP 800-53
-          revision 5.",
-        "implemented-requirements" [{
+        "description": "MongoDB control implementations for NIST SP 800-53 revision 5.",
+        "implemented-requirements": [{
           "uuid": "cf8338c5-fb6e-4593-a4a8-b3c4946ee2a0",
           "control-id": "sc-8.1",
-          "description": "MongoDB supports TLS 1.x to encrypt data in transit,
-            preventing unauthorized disclosure or changes to information
-            during transmission. To implement TLS, set the PEMKeyFile option
-            in the configuration file /etc/mongod.conf to the certificate
-            file's path and restart the the component."
+          "description": "MongoDB supports TLS 1.x to encrypt data in transit, preventing unauthorized disclosure or changes to information during transmission. To implement TLS, set the PEMKeyFile option in the configuration file /etc/mongod.conf to the certificate file's path and restart the the component."
+        },
+        {
+          "uuid": "d1e2f3a4-b5c6-4d7e-8f9a-0b1c2d3e4f5a",
+          "control-id": "sa-4.9",
+          "description": "Must ensure that MongoDB only listens for network connections on authorized interfaces by configuring the MongoDB configuration file to limit the services exposure to only the network interfaces on which MongoDB instances should listen for incoming connections."
         }]
       }]
     }]
@@ -703,8 +703,8 @@ component-definition:
   metadata:
     title: MongoDB Component Definition Example
     last-modified: '2001-12-17T09:30:47Z'
-    version: 20210507
-    oscal-version: 1.0.0
+    version: '20210507'
+    oscal-version: '1.2.2'
     roles:
     - id: provider
       title: Provider
@@ -726,7 +726,8 @@ component-definition:
     purpose: Provides a NoSQL database service
     responsible-roles:
     - role-id: provider
-      party-uuid: ef7c799a-c50e-49ab-83e0-515e989e6df1
+      party-uuids:
+      - ef7c799a-c50e-49ab-83e0-515e989e6df1
     protocols:
     - uuid: 2b4a1b3a-cbc5-4cc8-bde6-7437c28c4e54
       name: mongodb
@@ -753,7 +754,8 @@ component-definition:
     - uuid: 49f0b690-ed9f-4f32-aae0-625b77aa6d27
       source: <https://github.com/usnistgov/oscal-content/blob/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json>
       description: >-
-        MongoDB control implementations for NIST SP 800-53rev5.
+        MongoDB control implementations for NIST SP 800-53
+        revision 5.
       implemented-requirements:
       - uuid: cf8338c5-fb6e-4593-a4a8-b3c4946ee2a0
         control-id: sc-8.1
@@ -763,6 +765,14 @@ component-definition:
           transmission. To implement TLS, set the PEMKeyFile option in the
           configuration file /etc/mongod.conf to the certificate file's path
           and restart the the component.
+      - uuid: d1e2f3a4-b5c6-4d7e-8f9a-0b1c2d3e4f5a
+        control-id: sa-4.9
+        description: >-
+          Must ensure that MongoDB only listens for network connections on
+          authorized interfaces by configuring the MongoDB configuration
+          file to limit the services exposure to only the network
+          interfaces on which MongoDB instances should listen for incoming
+          connections.
 {{< /highlight >}}
 {{% /tab %}}
 {{% /tabs %}}
@@ -777,4 +787,4 @@ This concludes the tutorial.  You should now be familiar with:
 - How to use the protocol elements in a component.
 - How to specify the control implementation for a component.
 
-For more information, you can review the OSCAL component definition model [documentation](/concepts/layer/implementation/component-definition/).
+For more information, you can review the OSCAL component definition model [documentation](/concepts/layer/implementation/component-definition/). To see other component-definition use cases, check out the [Creating a Policy Component](/learn/tutorials/implementation/policy-component-definition/) and [Modeling a Capability Component](/learn/tutorials/implementation/capability-component-definition/) tutorials.


### PR DESCRIPTION
## Summary

This PR is submitted in support of the OSCAL Foundation's Component Definition (CDef) working group. It extends the site's implementation-layer tutorials to cover additional `component-definition` use cases and to demonstrate a pattern currently under discussion within the working group.

The existing "Creating a Component Definition" tutorial covered a single use case (a `type="software"`/`"service"` component). This PR splits the material into three dedicated pages so that each use case can be presented in full, and adds coverage of a `type="policy"` component and a proposed `type="capability"` component pattern.

## Changes

- **`simple-component-definition.md`** (existing page, trimmed): now scoped to the foundational software/service walkthrough. Several pre-existing schema conformance issues were identified and corrected in the process (see "Schema validation" below).
- **`policy-component-definition.md`** (new): demonstrates a `type="policy"` component, using an Incident Response Policy satisfying **IR-1** as the running example. Introduces citation of an external policy document via a `back-matter` resource.
- **`capability-component-definition.md`** (new): demonstrates the `type="capability"` / `incorporates-components` pattern currently proposed to the OSCAL community for representing capabilities as components (so that the aggregate relationship can carry into a system security plan using existing component mechanics). This pattern is **not part of the current OSCAL schema**; the tutorial explicitly and repeatedly frames it as a proposal under CDef working group discussion, not a supported feature, and links back to the existing `<capability>`/`capabilities` element as the current, supported mechanism.
- Updated the four hub/index pages that hand-link to implementation-layer tutorials (`learn/_index.md`, `tutorials/_index.md`, `tutorials/implementation/_index.md`, and the `component-definition` concept page's "Related Tutorials" section) to reference the two new pages.

## Schema validation

Every OSCAL example in all three tutorials (XML, JSON, and YAML) was checked against the official `component-definition` JSON Schema for OSCAL **v1.2.2**, downloaded from the [usnistgov/OSCAL v1.2.2 release assets](https://github.com/usnistgov/OSCAL/releases/tag/v1.2.2). This surfaced and corrected a number of pre-existing issues in the original tutorial that predate this PR, including:

- Invalid JSON (a missing colon, and multi-line string literals that are not valid JSON).
- `version` represented as a bare number instead of the required string type.
- `party.links` represented as a bare string instead of a `link` array.
- `responsible-roles[].party-uuid` (singular) instead of the correct `party-uuids` (plural array).
- A duplicate UUID reused across two distinct `implemented-requirement`s.
- A YAML example missing an `implemented-requirement` that was present in the equivalent XML/JSON.
- `oscal-version` referencing an outdated `1.0.0`, updated to `1.2.2`.

All full example instances in all three tutorials now validate cleanly against the v1.2.2 schema, with the sole intentional exception of `type="capability"` / `incorporates-components` on a `component` in the capability tutorial, which is explicitly called out as a proposal rather than current schema-conformant OSCAL.

## Test plan

- [ ] Run `make serve` (or the Docker Compose Hugo server) and visually confirm all three tutorial pages render correctly, including tab switching and syntax-highlighted code blocks.
- [ ] Confirm the new cards/links on the four hub pages resolve correctly.
- [ ] Run `make linkcheck` to confirm no broken links were introduced.